### PR TITLE
Make max buffer size refer to byte length not string length

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1388,7 +1388,7 @@ function runTests(createApp: () => App): void {
       app.post(endpoint(), persistedQueries({ queryMap }), graphqlHTTP({ schema }));
 
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      const body = Buffer.alloc(100 * UNIT_KIB + 1, 'a').toString();
+      const body = Buffer.alloc(100 * UNIT_KIB + 1, 'I ♥ GraphQL').toString();
 
       const response = await request(app).post(endpoint()).type('json').send(body);
 
@@ -1408,7 +1408,7 @@ function runTests(createApp: () => App): void {
       app.post(endpoint(), persistedQueries({ queryMap }), graphqlHTTP({ schema }));
 
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      const body = Buffer.alloc(100 * UNIT_KIB, 'a').toString();
+      const body = Buffer.alloc(100 * UNIT_KIB, 'I ♥ GraphQL').toString();
 
       const response = await request(app).post(endpoint()).type('json').send(body);
 

--- a/src/parseRequestBodyIfNecessary.ts
+++ b/src/parseRequestBodyIfNecessary.ts
@@ -62,9 +62,9 @@ async function readRawBody(req: Request, contentTypeInfo: ParsedMediaType): Prom
   const stream = getStreamFromRequest(req, encoding);
 
   try {
-    const body = await getStream(stream, { encoding: charset, maxBuffer });
+    const bodyBuffer = await getStream.buffer(stream, { maxBuffer });
 
-    return body;
+    return bodyBuffer.toString(charset);
   } catch (unknownError: unknown) {
     /* istanbul ignore else: cannot make get-stream throw other error. */
     if (unknownError instanceof MaxBufferError) {


### PR DESCRIPTION
When calling `getStream` directly, `maxBuffer` refers to the string length. However, we want to specify the max size in terms of bytes. This can be done by using [`getStream.buffer`](https://github.com/sindresorhus/get-stream#getstreambufferstream-options), for which `maxBuffer` refers to byte length, not string length.