### PR TITLE
Add pull request template and update link to create a new issue in CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+**Pull request type**
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Code style update
+- [ ] Refactoring (no functional changes and no API changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Other:
+
+**Describe the current behavior**
+...
+
+**Describe the new behavior**
+...
+
+**Issue**
+Resolves #
+
+**Is this a breaking change?**
+
+- [ ] Yes
+- [ ] No
+
+**Additional information**
+...
+
+**Checklist**
+
+- [ ] Commits follow the [commit message guidelines](https://github.com/kyarik/express-graphql-persisted-queries/blob/main/CONTRIBUTING.md#commit-message-guidelines).
+- [ ] Tests for the changes have been added (for bug fixes and features).
+- [ ] Documentation in the README was added/updated (for bug fixes and features).
+- [ ] TSDoc comments were added/updated (for bug fixes and features).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ If you want to implement a new feature, here's what you should do:
 
 If you want to create an issue, you should first search the [existing open/close issues](https://github.com/kyarik/express-graphql-persisted-queries/issues) to see if there's already an issue for the problem you have or the feature you want to request. In that case, you can read the discussion and contribute to it.
 
-Once you checked that there is no existing issue for your problem or feature request, you can create an issue by [filling this form](https://github.com/kyarik/express-graphql-persisted-queries/issues/new).
+Once you checked that there is no existing issue for your problem or feature request, you can create an issue by [filling this form](https://github.com/kyarik/express-graphql-persisted-queries/issues/new/choose).
 
 ## Creating a pull request
 


### PR DESCRIPTION
**Pull request type**
- Documentation changes
- Pull request template changes

**Describe the current behavior**
- PRs have no template.
- Link to create a new issue in `CONTRIBUTING.md` points to a blank new issue.

**Describe the new behavior**
- PRs have a template
- Link to create a new issue in `CONTRIBUTING.md` points to the issue template chooser.

**Is this a breaking change?**
No

**Checklist**

- [x] Commits follow the [commit message guidelines](https://github.com/kyarik/express-graphql-persisted-queries/blob/main/CONTRIBUTING.md#commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes and features).
- [x] Documentation in the README was added/updated (for bug fixes and features).
- [x] TSDoc comments were added/updated (for bug fixes and features).