### PR TITLE
Remove checkboxes from non-tasks in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,5 @@
 **Pull request type**
-
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Code style update
-- [ ] Refactoring (no functional changes and no API changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Documentation content changes
-- [ ] Other:
+Bug fix, Feature, Code style update, Refactoring (no functional changes and no API changes), Build related changes, CI related changes, Documentation changes, Other
 
 **Describe the current behavior**
 ...
@@ -19,9 +11,7 @@
 Resolves #
 
 **Is this a breaking change?**
-
-- [ ] Yes
-- [ ] No
+Yes/No
 
 **Additional information**
 ...


### PR DESCRIPTION
**Pull request type**
Pull request template changes

**Describe the current behavior**
Pull request type choices and breaking change choices are treated as tasks to be completed by GitHub.

**Describe the new behavior**
Pull request type is no longer a choice and breaking change is no longer a choice.


**Is this a breaking change?**
No

**Checklist**

- [x] Commits follow the [commit message guidelines](https://github.com/kyarik/express-graphql-persisted-queries/blob/main/CONTRIBUTING.md#commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes and features).
- [x] Documentation in the README was added/updated (for bug fixes and features).
- [x] TSDoc comments were added/updated (for bug fixes and features).
