### PR TITLE
Add `graphql` to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "typescript": "4.3.4"
   },
   "peerDependencies": {
-    "@types/node": "*"
+    "@types/node": "*",
+    "graphql": "^14.7.0 || ^15.3.0"
   }
 }


### PR DESCRIPTION
**Pull request type**
Bug fix

**Describe the current behavior**
At the moment, `express-graphql-persisted-queries` imports `graphql`, implicitly assuming that users have it as dependency.

**Describe the new behavior**
`graphql` is explicitly marked as a peer dependency.


**Is this a breaking change?**
No

**Checklist**

- [x] Commits follow the [commit message guidelines](https://github.com/kyarik/express-graphql-persisted-queries/blob/main/CONTRIBUTING.md#commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes and features).
- [x] Documentation in the README was added/updated (for bug fixes and features).
- [x] TSDoc comments were added/updated (for bug fixes and features).
