### PR TITLE
Add graphql dependency in TypeScript integration tests

### DIFF
--- a/integration-tests/typescript/package.json
+++ b/integration-tests/typescript/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@types/node": "15.6.1",
     "express-graphql-persisted-queries": "file:../express-graphql-persisted-queries.tgz",
+    "graphql": "15.5.1",
     "typescript-3.4": "npm:typescript@3.4.x",
     "typescript-3.5": "npm:typescript@3.5.x",
     "typescript-3.6": "npm:typescript@3.6.x",


### PR DESCRIPTION
**Pull request type**
Build related changes

**Describe the current behavior**
Currently the project with integration tests for typescript does not include  the `graphql` dependency, which is a peer dependency of  `express-graphql-persisted-queries`.

**Describe the new behavior**
The project with integration tests for typescript includes  the `graphql` dependency.


**Is this a breaking change?**
No

**Checklist**

- [x] Commits follow the [commit message guidelines](https://github.com/kyarik/express-graphql-persisted-queries/blob/main/CONTRIBUTING.md#commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes and features).
- [x] Documentation in the README was added/updated (for bug fixes and features).
- [x] TSDoc comments were added/updated (for bug fixes and features).
